### PR TITLE
creación del modelo y rutas de tickets de soporte

### DIFF
--- a/api/src/controllers/tickets/deleteTicket.js
+++ b/api/src/controllers/tickets/deleteTicket.js
@@ -1,0 +1,14 @@
+import Ticket from '../../models/Ticket.js'
+
+const deleteTicket = async (req, res) => {
+  try {
+    const { id } = req.params
+
+    await Ticket.findByIdAndDelete(id)
+    res.status(200).json('Ticket borrado con éxito')
+  } catch (error) {
+    res.status(400).json({ error: error.message })
+  }
+}
+
+export default deleteTicket

--- a/api/src/controllers/tickets/getTickets.js
+++ b/api/src/controllers/tickets/getTickets.js
@@ -1,0 +1,13 @@
+import Ticket from '../../models/Ticket.js'
+
+const getAllTickets = async (req, res) => {
+  try {
+    const allTickets = await Ticket.find()
+
+    res.status(200).json(allTickets)
+  } catch (error) {
+    res.status(400).send({ error: error.message })
+  }
+}
+
+export default getAllTickets

--- a/api/src/controllers/tickets/ticketPost.js
+++ b/api/src/controllers/tickets/ticketPost.js
@@ -1,0 +1,43 @@
+import jwt from 'jsonwebtoken'
+
+import Ticket from '../../models/Ticket.js'
+import User from '../../models/User.js'
+
+const createTicket = async (req, res) => {
+  try {
+    const { subject, content } = req.body
+
+    if (!subject || !content) res.status(401).send('Missin information')
+    const authorization = req.get('authorization')
+
+    if (authorization.length <= 7) {
+      res.status(401).json('token missing')
+    }
+    if (authorization && authorization.toLowerCase().startsWith('bearer ')) {
+      const token = authorization.substring(7)
+      const decodedToken = jwt.verify(token, process.env.SECRET)
+
+      if (!token || !decodedToken.id) {
+        return res.status(401).json({ error: 'token missing or invalid' })
+      }
+      const ownerTicketUser = await User.findById(decodedToken.id)
+
+      const ticket = new Ticket({
+        subject,
+        content,
+        user: ownerTicketUser._id,
+      })
+
+      await ticket.save()
+      res
+        .status(200)
+        .json(
+          `Tu ticket con asunto ${ticket.subject} con código único ${ticket.id} fue enviado a soporte`,
+        )
+    }
+  } catch (error) {
+    res.status(400).json({ error: error.message })
+  }
+}
+
+export default createTicket

--- a/api/src/models/Ticket.js
+++ b/api/src/models/Ticket.js
@@ -1,0 +1,30 @@
+import mongoose from 'mongoose'
+
+const TicketSchecma = new mongoose.Schema({
+  subject: String,
+  content: String,
+  resolve: {
+    type: Boolean,
+    default: false,
+  },
+  user: {
+    type: mongoose.Schema.Types.ObjectId,
+    ref: 'User',
+  },
+  createdAt: {
+    type: Date,
+    default: Date.now,
+  },
+})
+
+TicketSchecma.set('toJSON', {
+  transform: (document, returnedObject) => {
+    returnedObject.id = returnedObject._id.toString()
+    delete returnedObject._id
+    delete returnedObject.__v
+  },
+})
+
+const Ticket = mongoose.model('Ticket', TicketSchecma)
+
+export default Ticket

--- a/api/src/routes/index.js
+++ b/api/src/routes/index.js
@@ -10,6 +10,7 @@ import loginRouter from './Login/Login.routes.js'
 import checkOutRouter from './Checkout/Checkout.routes.js'
 import signupRouter from './Signup/signup.routes.js'
 import successRouter from './Success/Success.routes.js'
+import ticketRouter from './tickets/Ticket.routes.js'
 
 const router = Router()
 
@@ -36,6 +37,9 @@ router.use('/checkout', checkOutRouter)
 
 //= =====================success Routes================================
 router.use('/success', successRouter)
+
+//= =====================Tickets Routes================================
+router.use('/ticket', ticketRouter)
 
 //= =====================Error Middlewares================================
 

--- a/api/src/routes/tickets/Ticket.routes.js
+++ b/api/src/routes/tickets/Ticket.routes.js
@@ -1,0 +1,13 @@
+import { Router } from 'express'
+
+import createTicket from '../../controllers/tickets/ticketPost.js'
+import getAllTickets from '../../controllers/tickets/getTickets.js'
+import deleteTicket from '../../controllers/tickets/deleteTicket.js'
+
+const ticketRouter = Router()
+
+ticketRouter.get('/', getAllTickets)
+ticketRouter.post('/create', createTicket)
+ticketRouter.delete('/delete/:id', deleteTicket)
+
+export default ticketRouter


### PR DESCRIPTION
Se creó el modelo de tickets y tres rutas iniciales para la creación de tickets a soporte, para traer todos los tickets y para eliminar tickets (aún no tiene borrado lógico)